### PR TITLE
convert alle images naar rgba (32bit)

### DIFF
--- a/canvas.py
+++ b/canvas.py
@@ -19,7 +19,7 @@ async def get_canvas_part(canvas_id: Literal[0, 1, 2, 3, 4, 5]):
     printc(f'{now()} {GREEN}Downloading canvas from {BLUE}{canvas_url}')
     response = requests.get(canvas_url)
     # response.raise_for_status()
-    return Image.open(BytesIO(response.content))
+    return Image.open(BytesIO(response.content)).convert("RGBA")
 
 
 async def build_canvas_image(image_ids: List[Literal[0, 1, 2, 3, 4, 5, None]]) -> Image.Image:

--- a/images.py
+++ b/images.py
@@ -20,7 +20,7 @@ async def download_order_image(url):
         response = await client.get(url, timeout=2 * 60)
     response.raise_for_status()
 
-    order_img = Image.open(BytesIO(response.content))
+    order_img = Image.open(BytesIO(response.content)).convert("RGBA")
     order_img.save("chieftemplate.png")
     return order_img
 
@@ -30,7 +30,7 @@ async def download_priority_image(url):
         response = await client.get(url, timeout=2 * 60)
     response.raise_for_status()
 
-    priority_img = Image.open(BytesIO(response.content))
+    priority_img = Image.open(BytesIO(response.content)).convert("RGBA")
     priority_img.save("prioritymap.png")
     return priority_img
 

--- a/paste.py
+++ b/paste.py
@@ -22,8 +22,8 @@ import asyncio
 from PIL import Image
 
 #
-canvas = Image.open("canvas.png")
-chief_template = Image.open("chieftemplate.png")
+canvas = Image.open("canvas.png").convert("RGBA")
+chief_template = Image.open("chieftemplate.png").convert("RGBA")
 #
 #
 print("differences:", len(images.get_pixel_differences(canvas, chief_template)))


### PR DESCRIPTION
Heb dit niet getest meet de bot omdat ik dan een eigen chief installatie op moet zetten.

Heb dit wel getest door alleen `download_order_image` te gebruiken met de `.convert("RGBA")` toevoeging op [deze template](https://chief.placenl.nl/orders/9005d759-e4f9-4e98-949d-711fc653b8fe.png). daar komt dus een 32-bit color image uit.

